### PR TITLE
Fix spurious new lines.

### DIFF
--- a/src/cli.toit
+++ b/src/cli.toit
@@ -188,6 +188,22 @@ class Command:
     generator.build-all
     return generator.to-string
 
+  /**
+  The short help string of this command.
+
+  This is the first paragraph of the help string.
+  */
+  short-help -> string:
+    if help := short-help_:
+      return help
+    if long-help := help_:
+      // Take the first paragraph (potentially multiple lines) of the long help.
+      paragraph-index := long-help.index-of "\n\n"
+      if paragraph-index == -1:
+        return long-help.trim
+      return long-help[..paragraph-index].trim
+    return ""
+
   /** Returns the usage string of this command. */
   usage --invoked-command/string=system.program-name -> string:
     generator := HelpGenerator [this] --invoked-command=invoked-command

--- a/src/help-generator_.toit
+++ b/src/help-generator_.toit
@@ -150,10 +150,10 @@ class HelpGenerator:
   build-description -> none:
     if help := command_.help_:
       ensure-vertical-space_
-      writeln_ (help.trim --right)
+      writeln_ help.trim
     else if short-help := command_.short-help_:
       ensure-vertical-space_
-      writeln_ (short-help.trim --right)
+      writeln_ short-help.trim
 
   /**
   Builds the usage section.
@@ -241,18 +241,7 @@ class HelpGenerator:
 
       if subcommand.is-hidden_: continue.do
 
-      help-str := ?
-      if help := subcommand.short-help_:
-        help-str = help
-      else if long-help := subcommand.help_:
-        // Take the first paragraph (potentially multiple lines) of the long help.
-        paragraph-index := long-help.index-of "\n\n"
-        if paragraph-index == -1:
-          help-str = long-help
-        else:
-          help-str = long-help[..paragraph-index]
-      else:
-        help-str = ""
+      help-str := subcommand.short-help
       commands-and-help.add [subcommand.name, help-str]
 
     if not has-help-subcommand and is-root-command_:

--- a/tests/help_test.toit
+++ b/tests/help_test.toit
@@ -15,6 +15,7 @@ main:
   test-commands
   test-options
   test-examples
+  test-short-help
 
 check-output expected/string [block]:
   ui := TestUi
@@ -794,4 +795,46 @@ test-examples:
       app sub2 global1
     """
   actual = build-examples.call [cmd]
+  expect-equals expected actual
+
+test-short-help:
+  cmd := cli.Command "root"
+      --help="Test command."
+      --run=:: unreachable
+
+  expected := "Test command."
+  actual := cmd.short-help
+  expect-equals expected actual
+
+  cmd = cli.Command "root"
+      --help="""
+        Test command.
+        """
+      --run=:: unreachable
+
+  expected = "Test command."
+  actual = cmd.short-help
+  expect-equals expected actual
+
+  cmd = cli.Command "root"
+      --help="""
+        Test command.
+        Second line.
+        """
+      --run=:: unreachable
+
+  expected = "Test command.\nSecond line."
+  actual = cmd.short-help
+  expect-equals expected actual
+
+  cmd = cli.Command "root"
+      --help="""
+        Test command.
+
+        Second paragraph.
+        """
+      --run=:: unreachable
+
+  expected = "Test command."
+  actual = cmd.short-help
   expect-equals expected actual


### PR DESCRIPTION
Sometimes we had newlines when printing subcommands.

```
Commands:
  assets             Manipulate assets files.
  esp                ESP-IDF related commands.
  firmware           Manipulate firmware envelopes.
  kebabify           Migrates a project from snake-case to kebab-case.

  lsp                Start the language server.
  snapshot           Inspect a Toit snapshot.

  snapshot-to-image  Converts a snapshot into an image.
```

This was, because we didn't correctly trim the help.