### PR TITLE
Register UI options with custom CLI objects

### DIFF
--- a/src/cli.toit
+++ b/src/cli.toit
@@ -350,9 +350,9 @@ class Command:
 
   If no $cli is given, the arguments are parsed for `--verbose`, `--verbosity-level` and
     `--output-format` to create the appropriate UI object. If a $cli object is given,
-    then these arguments are ignored.
+    then these arguments do not change its UI.
 
-  The $add-ui-help flag is used to determine whether to include help for `--verbose`, ...
+  The $add-ui-help flag determines whether these UI options are accepted and included
     in the help output. By default it is active if no $cli is provided.
 
   The $completion-as-flag parameter controls whether shell completion is exposed as a
@@ -439,9 +439,8 @@ class Command:
     if not cli:
       ui := create-ui-from-args_ arguments
       log.set-default (ui.logger --name=name)
-      if add-ui-help:
-        add-ui-options_
       cli = Cli_ name --ui=ui --cache=null --config=null
+    if add-ui-help: add-ui-options_
     parser := Parser_ --invoked-command=invoked-command
     parser.parse this arguments: | path/Path parameters/Parameters |
       invocation := Invocation.private_ cli path.commands parameters

--- a/tests/command_group_options_test.toit
+++ b/tests/command_group_options_test.toit
@@ -18,6 +18,7 @@ When a subcommand is found on a CommandGroup, the parser goes directly
 main:
   test-commands-option-accessible-from-subcommand
   test-commands-option-accessible-with-value
+  test-ui-option-with-custom-cli
 
 test-commands-option-accessible-from-subcommand:
   sub-invoked := false
@@ -67,3 +68,22 @@ test-commands-option-accessible-with-value:
 
   root.run ["--sdk-dir", "/my/sdk", "run"]
   expect-equals "/my/sdk" captured-value
+
+test-ui-option-with-custom-cli:
+  captured-format := null
+  commands-cmd := cli.Command "commands"
+  commands-cmd.add
+      cli.Command "run"
+          --run=:: | invocation/cli.Invocation |
+            captured-format = invocation["output-format"]
+
+  root := cli.CommandGroup "app"
+      --default=(cli.Command "default"
+          --rest=[cli.Option "source" --required]
+          --run=:: unreachable)
+      --commands=commands-cmd
+
+  root.run ["--output-format", "json", "run"]
+      --cli=(cli.Cli "app" --ui=(cli.Ui.human --level=cli.Ui.SILENT-LEVEL))
+      --add-ui-help
+  expect-equals "json" captured-format


### PR DESCRIPTION
## Summary

- Register UI arguments when a caller supplies its own `Cli` object and enables `--add-ui-help`.
- Clarify that a supplied `Ui` itself is unchanged; the flag controls accepted UI arguments and help.
- Add a regression test using `CommandGroup`, a custom base `Cli`, and `--output-format=json`.

## Testing

- `make test` — 16/16 passed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>